### PR TITLE
Remove dependency on Redis for MoneyX

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Setup
 1. Install Gradle, the package manager, using ```sudo apt-get install gradle``` (Ubuntu/Debian) or ```brew install gradle``` (OSX).
 2. Make sure Java8 (listed as version 1.8) is installed and the default Java on your system. Obtaining this will depend on your OS, but generally you can download the Oracle JDK from their [website](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 3. Once in the code directly, run ```gradle build``` to assemble the app and pull in dependencies. You can also create a WAR file by running ```gradle war```.
-4. Set up a Redis server (```brew install redis``` or ```sudo apt-get install redis-server```), and run it. You can easily start it in a terminal using the ```redis-server``` command.
-6. Launch the application from the same directory with ```gradle run```
+4. Launch the application from the same directory with ```gradle run```
 
 Credentials
 ----

--- a/src/main/java/com/nvisium/androidnv/api/security/HttpSessionConfig.java
+++ b/src/main/java/com/nvisium/androidnv/api/security/HttpSessionConfig.java
@@ -1,13 +1,5 @@
 package com.nvisium.androidnv.api.security;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
-
 public class HttpSessionConfig {
-
-	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory();
-	}
 
 }

--- a/src/main/java/com/nvisium/androidnv/api/security/SecurityConfiguration.java
+++ b/src/main/java/com/nvisium/androidnv/api/security/SecurityConfiguration.java
@@ -9,14 +9,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
 import org.springframework.security.web.savedrequest.NullRequestCache;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 import com.nvisium.androidnv.api.service.UserService;
 
 @Configuration
 @EnableWebMvcSecurity
 @Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
-@EnableRedisHttpSession
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,8 +12,6 @@ server.ssl.key-store: keystore.p12
 server.ssl.key-store-password: mypassword
 server.ssl.keyStoreType: PKCS12
 server.ssl.keyAlias: tomcat
-spring.redis.host=localhost
-spring.redis.port=6379
 security.require-ssl=true
 
 security.headers.xss=false


### PR DESCRIPTION
Removes the requirement for Redis to be set up and installed for MoneyX to run. Also updated the README to reflect this.
